### PR TITLE
Specify where to add the plugin in 'Oh My ZSH!' installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Then load as a plugin in your `.zshrc`
 plugins+=(zsh-nvm)
 ```
 
+Keep in mind that plugins need to be added before `oh-my-zsh.sh` is sourced.
+
 ### Manually
 Clone this repository somewhere (`~/.zsh-nvm` for example)
 


### PR DESCRIPTION
I typically add commands for `.zshrc` to a (version controlled) file.
That file is sourced at the end of `.zshrc` (after `oh-my-zsh.sh` is loaded).
Took me a couple of minutes to figure out why the plugin is not loaded. :smile: