### PR TITLE
NVM_AUTO_USE

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ export NVM_NO_USE=true
 antigen bundle lukechilds/zsh-nvm
 ```
 
+### Auto use
+
+If you have lots of projects with an `.nvmrc` file you may find the auto use option helpful. If it's enabled, when you `cd` into a directory with an `.nvmrc` file, `zsh-nvm` will automatically load or install the required node version in `.nvmrc`. You can enable it by exporting the `NVM_AUTO_USE` environment variable and setting it to `true`. It must be set before `zsh-nvm` is loaded.
+
+If you enable this option and don't have `nvm` loaded in the current session (`NVM_LAZY_LOAD` or `NVM_NO_USE`) it won't work until you've loaded `nvm`.
+
+For example, if you are using antigen, you would put the following in your `.zshrc`:
+
+```shell
+export NVM_AUTO_USE=true
+antigen bundle lukechilds/zsh-nvm
+```
+
 ## Installation
 
 ### Using [Antigen](https://github.com/zsh-users/antigen)

--- a/tests/options/NVM_AUTO_USE
+++ b/tests/options/NVM_AUTO_USE
@@ -1,0 +1,42 @@
+#!/bin/sh
+source ../common.sh
+
+# Setup .nvmrc dir
+local nvmrc_dir="$test_dir/nvmrc"
+local no_nvmrc_dir="$test_dir/no-nvmrc"
+local nvmrc="$nvmrc_dir/.nvmrc"
+mkdir "$no_nvmrc_dir"
+mkdir "$nvmrc_dir"
+touch "$nvmrc"
+
+# Set NVM_AUTO_USE to true
+export NVM_AUTO_USE=true
+
+# Load zsh-nvm
+load_zsh_nvm
+
+# Install Node.js 5
+nvm install 5 && [[ "$(node --version)" == "v5."* ]] || die "node 5 wasn't installed"
+
+# Install Node.js 6
+nvm install 6 && [[ "$(node --version)" == "v6."* ]] || die "node 5 wasn't installed"
+
+# Check cd into folder with .nvmrc uses v5
+echo 5 > "$nvmrc"
+(cd "$nvmrc_dir" && [[ "$(node --version)" == "v5."* ]]) || die "Didn't auto switch to node 5"
+
+# Check cd into folder with .nvmrc keeps v6
+echo 6 > "$nvmrc"
+(cd "$nvmrc_dir" && [[ "$(node --version)" == "v6."* ]]) || die "Didn't keep node 5"
+
+# Check cd into folder with .nvmrc installs v7
+echo 7 > "$nvmrc"
+(cd "$nvmrc_dir" && [[ "$(node --version)" == "v7."* ]]) || die "Didn't install node 7"
+nvm alias default 6 # Make sure 6 is still default not 7
+
+# Check cd into folder with no .nvmrc keeps manually set version
+(nvm use 5 && cd "$no_nvmrc_dir" && [[ "$(node --version)" == "v5."* ]]) || die "Reverted to default node version after manual use and cd"
+
+# Check cd into folder with no .nvmrc reverts to default version after auto use
+echo 5 > "$nvmrc"
+(cd "$nvmrc_dir" && [[ "$(node --version)" == "v5."* ]] && cd "$no_nvmrc_dir" && [[ "$(node --version)" == "v6."* ]]) || die "Didn't revert to default node version after auto use and cd"

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -158,7 +158,7 @@ _zsh_nvm_auto_use() {
     local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
 
     if [ "$nvmrc_node_version" != "N/A" ] && [ "$nvmrc_node_version" != "$node_version" ]; then
-      nvm install
+      nvm use
     fi
   elif [ "$node_version" != "$(nvm version default)" ]; then
     echo "Reverting to nvm default version"

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -57,6 +57,10 @@ _zsh_nvm_load() {
       'revert')
         _zsh_nvm_revert
         ;;
+      'use')
+        _zsh_nvm_nvm "$@"
+        export NVM_AUTO_USE_ACTIVE=false
+        ;;
       *)
         _zsh_nvm_nvm "$@"
         ;;
@@ -159,8 +163,9 @@ _zsh_nvm_auto_use() {
 
     if [ "$nvmrc_node_version" != "N/A" ] && [ "$nvmrc_node_version" != "$node_version" ]; then
       nvm use
+      export NVM_AUTO_USE_ACTIVE=true
     fi
-  elif [ "$node_version" != "$(nvm version default)" ]; then
+  elif [ "$node_version" != "$(nvm version default)" ] && [ "$NVM_AUTO_USE_ACTIVE" = true ]; then
     echo "Reverting to nvm default version"
     nvm use default
   fi

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -183,3 +183,5 @@ if [[ "$ZSH_NVM_NO_LOAD" != true ]]; then
   fi
 
 fi
+
+return true

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -147,6 +147,23 @@ _zsh_nvm_revert() {
   fi
 }
 
+autoload -U add-zsh-hook
+_zsh_nvm_auto_use() {
+  local node_version="$(nvm version)"
+  local nvmrc_path="$(nvm_find_nvmrc)"
+
+  if [ -n "$nvmrc_path" ]; then
+    local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+
+    if [ "$nvmrc_node_version" != "N/A" ] && [ "$nvmrc_node_version" != "$node_version" ]; then
+      nvm install
+    fi
+  elif [ "$node_version" != "$(nvm version default)" ]; then
+    echo "Reverting to nvm default version"
+    nvm use default
+  fi
+}
+
 # Don't init anything if this is true (debug/testing only)
 if [[ "$ZSH_NVM_NO_LOAD" != true ]]; then
 
@@ -158,6 +175,9 @@ if [[ "$ZSH_NVM_NO_LOAD" != true ]]; then
 
     # Load it
     [[ "$NVM_LAZY_LOAD" == true ]] && _zsh_nvm_lazy_load || _zsh_nvm_load
+
+    # Auto use nvm on chpwd
+    [[ "$NVM_AUTO_USE" == true ]] && add-zsh-hook chpwd _zsh_nvm_auto_use && _zsh_nvm_auto_use
   fi
 
 fi

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -161,10 +161,10 @@ _zsh_nvm_auto_use() {
   if [[ -n "$nvmrc_path" ]]; then
     local nvmrc_node_version="$(nvm version $(cat "$nvmrc_path"))"
 
-    if [[ "$nvmrc_node_version" != "N/A" ]]; then
-      [[ "$nvmrc_node_version" != "$node_version" ]] && nvm use && export NVM_AUTO_USE_ACTIVE=true
-    else
+    if [[ "$nvmrc_node_version" = "N/A" ]]; then
       nvm install && export NVM_AUTO_USE_ACTIVE=true
+    elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
+      nvm use && export NVM_AUTO_USE_ACTIVE=true
     fi
   elif [[ "$node_version" != "$(nvm version default)" ]] && [[ "$NVM_AUTO_USE_ACTIVE" = true ]]; then
     echo "Reverting to nvm default version"

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -158,14 +158,14 @@ _zsh_nvm_auto_use() {
   local node_version="$(nvm version)"
   local nvmrc_path="$(nvm_find_nvmrc)"
 
-  if [ -n "$nvmrc_path" ]; then
+  if [[ -n "$nvmrc_path" ]]; then
     local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
 
-    if [ "$nvmrc_node_version" != "N/A" ] && [ "$nvmrc_node_version" != "$node_version" ]; then
+    if [[ "$nvmrc_node_version" != "N/A" ]] && [[ "$nvmrc_node_version" != "$node_version" ]]; then
       nvm use
       export NVM_AUTO_USE_ACTIVE=true
     fi
-  elif [ "$node_version" != "$(nvm version default)" ] && [ "$NVM_AUTO_USE_ACTIVE" = true ]; then
+  elif [[ "$node_version" != "$(nvm version default)" ]] && [[ "$NVM_AUTO_USE_ACTIVE" = true ]]; then
     echo "Reverting to nvm default version"
     nvm use default
   fi

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -159,7 +159,7 @@ _zsh_nvm_auto_use() {
   local nvmrc_path="$(nvm_find_nvmrc)"
 
   if [[ -n "$nvmrc_path" ]]; then
-    local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+    local nvmrc_node_version="$(nvm version $(cat "$nvmrc_path"))"
 
     if [[ "$nvmrc_node_version" != "N/A" ]]; then
       [[ "$nvmrc_node_version" != "$node_version" ]] && nvm use && export NVM_AUTO_USE_ACTIVE=true

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -161,9 +161,10 @@ _zsh_nvm_auto_use() {
   if [[ -n "$nvmrc_path" ]]; then
     local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
 
-    if [[ "$nvmrc_node_version" != "N/A" ]] && [[ "$nvmrc_node_version" != "$node_version" ]]; then
-      nvm use
-      export NVM_AUTO_USE_ACTIVE=true
+    if [[ "$nvmrc_node_version" != "N/A" ]]; then
+      [[ "$nvmrc_node_version" != "$node_version" ]] && nvm use && export NVM_AUTO_USE_ACTIVE=true
+    else
+      nvm install && export NVM_AUTO_USE_ACTIVE=true
     fi
   elif [[ "$node_version" != "$(nvm version default)" ]] && [[ "$NVM_AUTO_USE_ACTIVE" = true ]]; then
     echo "Reverting to nvm default version"

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -149,6 +149,8 @@ _zsh_nvm_revert() {
 
 autoload -U add-zsh-hook
 _zsh_nvm_auto_use() {
+  _zsh_nvm_has nvm_find_nvmrc || return
+
   local node_version="$(nvm version)"
   local nvmrc_path="$(nvm_find_nvmrc)"
 


### PR DESCRIPTION
Automatically use the Node.js version specified in the current `.nvmrc` on cd.