### PR TITLE
Avoid printing on console when no binary found.

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -89,7 +89,7 @@ _zsh_nvm_lazy_load() {
   local cmds
   cmds=()
   for bin in $global_binaries; do
-    [[ "$(which $bin)" = "$bin: aliased to "* ]] || cmds+=($bin)
+    [[ "$(which $bin 2>/dev/null)" = "$bin: aliased to "* ]] || cmds+=($bin)
   done
 
   # Create function for each command


### PR DESCRIPTION
was getting `/usr/bin/which: no node in (/usr...` on every new session opened.