### PR TITLE
Mute unset output from lazy loaders

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -100,7 +100,7 @@ _zsh_nvm_lazy_load() {
 
     # When called, unset all lazy loaders, load nvm then run current command
     eval "$cmd(){
-      unset -f $cmds
+      unset -f $cmds > /dev/null 2>&1
       _zsh_nvm_load
       $cmd \"\$@\"
     }"


### PR DESCRIPTION
Resolves https://github.com/lukechilds/zsh-nvm/issues/31

Unset may give warning that lazy loaders don't exist, mute this, it's not important and looks messy in the terminal.