### PR TITLE
silent `which nvm` error in lazy load mode

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -92,7 +92,7 @@ _zsh_nvm_lazy_load() {
   local cmds
   cmds=()
   for bin in $global_binaries; do
-    [[ "$(which $bin)" = "$bin: aliased to "* ]] || cmds+=($bin)
+    [[ "$(which $bin 2> /dev/null)" = "$bin: aliased to "* ]] || cmds+=($bin)
   done
 
   # Create function for each command


### PR DESCRIPTION
GNU `which` prints an error to stderr when a binary is not found, that is displayed with every new terminal startup when zsh-nvm is in lazy load mode:

`/usr/local/bin/gwhich: no nvm in (...)`

This patch redirects `which` errors to `/dev/null` while keeping stdout output available.