### PR TITLE
Make `nvm upgrade` follow the official git upgrade instructions from nvm

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -13,7 +13,7 @@ _zsh_nvm_has() {
 }
 
 _zsh_nvm_latest_release_tag() {
-  echo $(cd "$NVM_DIR" && git fetch --quiet origin && git describe --abbrev=0 --tags --match "v[0-9]*" origin)
+  echo $(cd "$NVM_DIR" && git fetch --quiet --tags origin && git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1))
 }
 
 _zsh_nvm_install() {


### PR DESCRIPTION
I had the same problem as in #44 so I have looked into the code and saw that the official upgrade instructions aren't used as @lukechilds said in this [comment](https://github.com/lukechilds/zsh-nvm/issues/44#issuecomment-374898544).