### PR TITLE
Add experimental NVM path caching

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -83,13 +83,13 @@ _zsh_nvm_load() {
 _zsh_nvm_lazy_load() {
   if [[ "$NVM_CACHE_LOAD" == true ]] && [[ -s "${HOME}/.zsh_nvm_cache" ]]; then
     export NVM_CACHE_LOAD_PATH_NVM="$(cat "${HOME}/.zsh_nvm_cache")"
-    
+
     # Add it to path if it doesn't already exist.
     if [ -d "$NVM_CACHE_LOAD_PATH_NVM" ] && [[ ":$PATH:" != *":$NVM_CACHE_LOAD_PATH_NVM:"* ]]; then
-      export PATH="${PATH:+"$PATH:"}${NVM_CACHE_LOAD_PATH_NVM}"
+      export PATH="${NVM_CACHE_LOAD_PATH_NVM}${PATH:+":$PATH"}"
     fi
   fi
-  
+
   # Get all global node module binaries including node
   # (only if NVM_NO_USE is off)
   local global_binaries

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -38,11 +38,20 @@ _zsh_nvm_global_binaries() {
 
 _zsh_nvm_load() {
 
+  if [[ "$NVM_CACHE_LOAD" == true ]]; then
+      # Strip out the old cached version of node that we were using.
+      export PATH="$(sed -e 's|[^:]*versions/node[^:]*[:]||g' <<< "$PATH")"
+  fi
+
   # Source nvm (check if `nvm use` should be ran after load)
   if [[ "$NVM_NO_USE" == true ]]; then
     source "$NVM_DIR/nvm.sh" --no-use
   else
     source "$NVM_DIR/nvm.sh"
+    if [[ "$NVM_CACHE_LOAD" == true ]]; then
+      export NVM_CACHE_LOAD_PATH_NVM="$(awk -F ':' '{ print $1 }' <<< "$PATH")"
+      echo "$NVM_CACHE_LOAD_PATH_NVM" > "${HOME}/.zsh_nvm_cache"
+    fi
   fi
 
   # Rename main nvm function
@@ -72,7 +81,15 @@ _zsh_nvm_load() {
 }
 
 _zsh_nvm_lazy_load() {
-
+  if [[ "$NVM_CACHE_LOAD" == true ]] && [[ -s "${HOME}/.zsh_nvm_cache" ]]; then
+    export NVM_CACHE_LOAD_PATH_NVM="$(cat "${HOME}/.zsh_nvm_cache")"
+    
+    # Add it to path if it doesn't already exist.
+    if [ -d "$NVM_CACHE_LOAD_PATH_NVM" ] && [[ ":$PATH:" != *":$NVM_CACHE_LOAD_PATH_NVM:"* ]]; then
+      export PATH="${PATH:+"$PATH:"}${NVM_CACHE_LOAD_PATH_NVM}"
+    fi
+  fi
+  
   # Get all global node module binaries including node
   # (only if NVM_NO_USE is off)
   local global_binaries


### PR DESCRIPTION
This solves #30, per my speculation. Simply add `export NVM_CACHE_LOAD=true` (in addition to lazy loading) before the plugin is loaded into your plugin manager and it will cache the most recently used NVM path and preload it into `$PATH`. It strips it back out before sourcing NVM (which then adds in a fresh path). Negligible overhead.