### PR TITLE
Allow use of NVM_AUTO_USE alongside NVM_LAZY_LOAD on init

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -102,6 +102,7 @@ _zsh_nvm_lazy_load() {
     eval "$cmd(){
       unset -f $cmds > /dev/null 2>&1
       _zsh_nvm_load
+      [[ "$NVM_AUTO_USE" == true ]] && add-zsh-hook chpwd _zsh_nvm_auto_use && _zsh_nvm_auto_use
       $cmd \"\$@\"
     }"
   done


### PR DESCRIPTION
Right now, `NVM_AUTO_USE=true` will not get applied on the initial call of `nvm`/`npm`/`node`/`yarn`, and only work on subsequent session directory changes. This PR makes `NVM_AUTO_USE=true` go into effect at the first invocation when `NVM_LAZY_LOAD=true`.

Note - I'm good enough at tinkering in shell scripts, but totally could be doing something dumb here! Thanks for taking a look and making a great plugin!