### PR TITLE
Use builtin cd command

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -13,13 +13,13 @@ _zsh_nvm_has() {
 }
 
 _zsh_nvm_latest_release_tag() {
-  echo $(cd "$NVM_DIR" && git fetch --quiet --tags origin && git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1))
+  echo $(builtin cd "$NVM_DIR" && git fetch --quiet --tags origin && git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1))
 }
 
 _zsh_nvm_install() {
   echo "Installing nvm..."
   git clone https://github.com/nvm-sh/nvm.git "$NVM_DIR"
-  $(cd "$NVM_DIR" && git checkout --quiet "$(_zsh_nvm_latest_release_tag)")
+  $(builtin cd "$NVM_DIR" && git checkout --quiet "$(_zsh_nvm_latest_release_tag)")
 }
 
 _zsh_nvm_global_binaries() {
@@ -119,7 +119,7 @@ _zsh_nvm_upgrade() {
   fi
 
   # Otherwise use our own
-  local installed_version=$(cd "$NVM_DIR" && git describe --tags)
+  local installed_version=$(builtin cd "$NVM_DIR" && git describe --tags)
   echo "Installed version is $installed_version"
   echo "Checking latest version of nvm..."
   local latest_version=$(_zsh_nvm_latest_release_tag)
@@ -128,7 +128,7 @@ _zsh_nvm_upgrade() {
   else
     echo "Updating to $latest_version..."
     echo "$installed_version" > "$ZSH_NVM_DIR/previous_version"
-    $(cd "$NVM_DIR" && git fetch --quiet && git checkout "$latest_version")
+    $(builtin cd "$NVM_DIR" && git fetch --quiet && git checkout "$latest_version")
     _zsh_nvm_load
   fi
 }
@@ -140,14 +140,14 @@ _zsh_nvm_previous_version() {
 _zsh_nvm_revert() {
   local previous_version="$(_zsh_nvm_previous_version)"
   if [[ -n "$previous_version" ]]; then
-    local installed_version=$(cd "$NVM_DIR" && git describe --tags)
+    local installed_version=$(builtin cd "$NVM_DIR" && git describe --tags)
     if [[ "$installed_version" = "$previous_version" ]]; then
       echo "Already reverted to $installed_version"
       return
     fi
     echo "Installed version is $installed_version"
     echo "Reverting to $previous_version..."
-    $(cd "$NVM_DIR" && git checkout "$previous_version")
+    $(builtin cd "$NVM_DIR" && git checkout "$previous_version")
     _zsh_nvm_load
   else
     echo "No previous version found"


### PR DESCRIPTION
Use the shell's builtin cd command.

Some people (like me) have modified cd so it prints extra info or does other things (like pushd) when changing directories. This adds the builtin command so it use's the shells version instead.