### PR TITLE
Add the ability to exclude specific cases from NVM_AUTO_USE

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > Zsh plugin for installing, updating and loading `nvm`
 
+[![GitHub Donate](https://badgen.net/badge/GitHub/Sponsor/D959A7?icon=github)](https://github.com/sponsors/lukechilds)
+[![Bitcoin Donate](https://badgen.net/badge/Bitcoin/Donate/F19537?icon=bitcoin)](https://lu.ke/tip/bitcoin)
+[![Lightning Donate](https://badgen.net/badge/Lightning/Donate/F6BC41?icon=bitcoin-lightning)](https://lu.ke/tip/lightning)
+
 [`nvm`](https://github.com/nvm-sh/nvm) is an awesome tool but it can be kind of a pain to install and keep up to date. This zsh plugin allows you to quickly setup `nvm` once, save it in your dotfiles, then never worry about it again.
 
 The plugin will install the latest stable release of `nvm` if you don't already have it, and then automatically `source` it for you. You can upgrade `nvm` to the latest version whenever you want without losing your installed `node` versions by running `nvm upgrade`.

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -173,7 +173,7 @@ _current_node_version() {
 
 _node_is_nvm() {
   local node_path="$(command which node 2>/dev/null)"
-  if [[ -z "${node_path##$NVM_DIR*}" ]]; then
+  if [[ -n "$node_path" && -z "${node_path##$NVM_DIR*}" ]]; then
     return 0
   else
     return 1

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -169,9 +169,15 @@ _zsh_nvm_auto_use() {
   local nvmrc_path="$(nvm_find_nvmrc)"
 
   if [[ -n "$nvmrc_path" ]]; then
+    local nvmrc_dir="$(dirname "$nvmrc_path")"
+    local nvmrc_version="$(cat "$nvmrc_path")"
     local nvmrc_node_version="$(nvm version $(cat "$nvmrc_path"))"
 
-    if [[ "$nvmrc_node_version" = "N/A" ]]; then
+    if [[ -v NVM_AUTO_USE_IGNORE_VERSION ]] && [[ ${NVM_AUTO_USE_IGNORE_VERSION[(Ie)$nvmrc_version]} -gt 0 ]]; then
+      echo "Detected nvm version <$nvmrc_version>, but this version is set to be ignored"
+    elif [[ -v NVM_AUTO_USE_IGNORE_PATH ]] && [[ ${NVM_AUTO_USE_IGNORE_PATH[(Ie)$nvmrc_dir]} -gt 0 ]]; then
+      echo "Detected nvm version <$nvmrc_version>, but this path is set to be ignored"
+    elif [[ "$nvmrc_node_version" = "N/A" ]]; then
       nvm install && export NVM_AUTO_USE_ACTIVE=true
     elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
       nvm use && export NVM_AUTO_USE_ACTIVE=true

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -162,11 +162,19 @@ _zsh_nvm_revert() {
 }
 
 _current_node_version() {
-  local node_path="$(command which node 2>/dev/null)"
-  if [[ -z "${node_path##$NVM_DIR*}" ]]; then
+  if _node_is_nvm; then
     node --version 2>/dev/null
   else
     printf 'system'
+  fi
+}
+
+_node_is_nvm() {
+  local node_path="$(command which node 2>/dev/null)"
+  if [[ -z "${node_path##$NVM_DIR*}" ]]; then
+    return 0
+  else
+    return 1
   fi
 }
 

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -204,8 +204,12 @@ _zsh_nvm_auto_use() {
       nvm use && export NVM_AUTO_USE_ACTIVE=true
     fi
   elif [[ "$NVM_AUTO_USE_ACTIVE" != false ]] && [[ "$node_version" != "$(_nvm_default_version)" ]]; then
-    [[ "$NVM_AUTO_USE_ACTIVE" = true ]] && echo "Reverting to nvm default version"
-    nvm use default
+    if [[ "$NVM_AUTO_USE_ACTIVE" = true ]]; then
+      echo "Reverting to nvm default version"
+      nvm use default
+    else
+      nvm use default >/dev/null
+    fi
   fi
 }
 

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -204,7 +204,7 @@ _zsh_nvm_auto_use() {
       nvm use && export NVM_AUTO_USE_ACTIVE=true
     fi
   elif [[ "$NVM_AUTO_USE_ACTIVE" != false ]] && [[ "$node_version" != "$(_nvm_default_version)" ]]; then
-    echo "Reverting to nvm default version"
+    [[ "$NVM_AUTO_USE_ACTIVE" = true ]] && echo "Reverting to nvm default version"
     nvm use default
   fi
 }

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -203,7 +203,7 @@ _zsh_nvm_auto_use() {
     elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
       nvm use && export NVM_AUTO_USE_ACTIVE=true
     fi
-  elif [[ "$NVM_AUTO_USE_ACTIVE" = true ]] && [[ "$node_version" != "$(_nvm_default_version)" ]]; then
+  elif [[ "$NVM_AUTO_USE_ACTIVE" != false ]] && [[ "$node_version" != "$(_nvm_default_version)" ]]; then
     echo "Reverting to nvm default version"
     nvm use default
   fi

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -22,6 +22,20 @@ _zsh_nvm_install() {
   $(builtin cd "$NVM_DIR" && git checkout --quiet "$(_zsh_nvm_latest_release_tag)")
 }
 
+_zsh_nvm_global_binaries() {
+
+  # Look for global binaries
+  local global_binary_paths="$(echo "$NVM_DIR"/v0*/bin/*(N) "$NVM_DIR"/versions/*/*/bin/*(N))"
+
+  # If we have some, format them
+  if [[ -n "$global_binary_paths" ]]; then
+    echo "$NVM_DIR"/v0*/bin/*(N) "$NVM_DIR"/versions/*/*/bin/*(N) |
+      xargs -n 1 basename |
+      sort |
+      uniq
+  fi
+}
+
 _zsh_nvm_load() {
 
   # Source nvm (check if `nvm use` should be ran after load)
@@ -71,7 +85,7 @@ _zsh_nvm_lazy_load() {
   if [[ "$NVM_NO_USE" == true ]]; then
     global_binaries=()
   else
-    global_binaries=("$NVM_DIR"/v0*/bin/*(N:t) "$NVM_DIR"/versions/*/*/bin/*(N:t))
+    global_binaries=($(_zsh_nvm_global_binaries))
   fi
 
   # Add yarn lazy loader if it's been installed by something other than npm
@@ -81,22 +95,19 @@ _zsh_nvm_lazy_load() {
   global_binaries+=('nvm')
   global_binaries+=($NVM_LAZY_LOAD_EXTRA_COMMANDS)
 
-  # Deduplicate
-  typeset -U global_binaries
-
   # Remove any binaries that conflict with current aliases
   local cmds
-  IFS=$'\n' cmds=($(whence -w -- "${global_binaries[@]}" 2> /dev/null))
-  unset IFS
-  cmds=(${cmds#*": alias"})
-  cmds=(${(@q-)cmds%": "*})
+  cmds=()
+  for bin in $global_binaries; do
+    [[ "$(which $bin 2> /dev/null)" = "$bin: aliased to "* ]] || cmds+=($bin)
+  done
 
   # Create function for each command
   for cmd in $cmds; do
 
     # When called, unset all lazy loaders, load nvm then run current command
     eval "$cmd(){
-      unset -f ${cmds[@]} > /dev/null 2>&1
+      unset -f $cmds > /dev/null 2>&1
       _zsh_nvm_load
       $cmd \"\$@\"
     }"

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -168,10 +168,10 @@ _zsh_nvm_auto_use() {
     return
   fi
 
-  local node_version="$(nvm version)"
   local nvmrc_path="$(nvm_find_nvmrc)"
 
   if [[ -n "$nvmrc_path" ]]; then
+    local node_version="$(nvm version)"
     local nvmrc_dir="$(dirname "$nvmrc_path")"
     local nvmrc_version="$(cat "$nvmrc_path")"
     local nvmrc_node_version="$(nvm version $(cat "$nvmrc_path"))"

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -203,13 +203,9 @@ _zsh_nvm_auto_use() {
     elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
       nvm use && export NVM_AUTO_USE_ACTIVE=true
     fi
-  elif [[ "$NVM_AUTO_USE_ACTIVE" != false ]] && [[ "$node_version" != "$(_nvm_default_version)" ]]; then
-    if [[ "$NVM_AUTO_USE_ACTIVE" = true ]]; then
-      echo "Reverting to nvm default version"
-      nvm use default
-    else
-      nvm use default >/dev/null
-    fi
+  elif [[ "$NVM_AUTO_USE_ACTIVE" = true ]] && [[ "$node_version" != "$(_nvm_default_version)" ]]; then
+    echo "Reverting to nvm default version"
+    nvm use default
   fi
 }
 

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -164,6 +164,9 @@ _zsh_nvm_revert() {
 autoload -U add-zsh-hook
 _zsh_nvm_auto_use() {
   _zsh_nvm_has nvm_find_nvmrc || return
+  if [[ $NVM_AUTO_USE != 'true' ]]; then
+    return
+  fi
 
   local node_version="$(nvm version)"
   local nvmrc_path="$(nvm_find_nvmrc)"

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -98,11 +98,13 @@ _zsh_nvm_lazy_load() {
   # Remove any binaries that conflict with current aliases
   local cmds
   cmds=()
+  local bin
   for bin in $global_binaries; do
     [[ "$(which $bin 2> /dev/null)" = "$bin: aliased to "* ]] || cmds+=($bin)
   done
 
   # Create function for each command
+  local cmd
   for cmd in $cmds; do
 
     # When called, unset all lazy loaders, load nvm then run current command


### PR DESCRIPTION
A git repo I have checked out locally recently added a `.nvmrc` with version 13.8.0.  I don't have that version installed, so every time I enter that directory, it starts trying to install 13.8.0, which I have to quickly cancel every time since there's no reason to install 13.8.0 when it is outdated but not LTS.

This PR adds support for the array environment variables `NVM_AUTO_USE_IGNORE_VERSION` and `NVM_AUTO_USE_IGNORE_PATH`. These are used to ignore specific values from `.nvmrc` and to ignore the `.nvmrc` in specific directories.

Examples (in `~/.zshrc`):
```shell
export NVM_AUTO_USE_IGNORE_VERSION=("v13.8.0" "lts/boron")
```
Auto-use will be skipped if the `.nvmrc` file it finds contains the values `v13.8.0` or `lts/boron`.

```shell
export NVM_AUTO_USE_IGNORE_PATH=("$HOME/projects/annoying-external-repo")
```
Auto-use will be skipped if the `.nvmrc` file it finds is `$HOME/projects/annoying-external-repo/.nvmrc`.