### PR TITLE
Add NVM_COMPLETION option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ antigen bundle lukechilds/zsh-nvm
 
 Note: If `nvm` doesn't exist in this directory it'll be automatically installed when you start a session.
 
+### Nvm Completion
+
+`nvm` comes with a default bash_completion profile. If you want to enable it, you can do it by exporting  the `NVM_COMPLETION` environment variable and setting it to `true`. It must be set before `zsh-nvm` is loaded.
+
+For example, if you are using antigen, you would put the following in your `.zshrc`:
+
+```bash
+# Export nvm completion settings for zsh-nvm plugin
+export NVM_COMPLETION=true
+antigen bundle lukechilds/zsh-nvm
+```
+
 ### Lazy Loading
 
 If you find `nvm` adds too much lag to your shell startup you can enable lazy loading by exporting the `NVM_LAZY_LOAD` environment variable and setting it to `true`. It must be set before `zsh-nvm` is loaded.

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -71,6 +71,12 @@ _zsh_nvm_load() {
   }
 }
 
+_zsh_nvm_completion() {
+
+  # Add provided nvm completion
+  [[ -r $NVM_DIR/bash_completion ]] && source $NVM_DIR/bash_completion
+}
+
 _zsh_nvm_lazy_load() {
 
   # Get all global node module binaries including node
@@ -207,6 +213,9 @@ if [[ "$ZSH_NVM_NO_LOAD" != true ]]; then
     # Load it
     [[ "$NVM_LAZY_LOAD" == true ]] && _zsh_nvm_lazy_load || _zsh_nvm_load
 
+    # Enable completion
+    [[ "$NVM_COMPLETION" == true ]] && _zsh_nvm_completion
+    
     # Auto use nvm on chpwd
     [[ "$NVM_AUTO_USE" == true ]] && add-zsh-hook chpwd _zsh_nvm_auto_use && _zsh_nvm_auto_use
   fi


### PR DESCRIPTION
Hello,

This closes #57 for nvm completion.  

Even if I would enable this by default, I introduced a new parameter `NVM_COMPLETION` to enable this feature, this way there are no breaking changes possible by default.

The completion is provided by the nvm core repository and enabled as mentioned in [the core installation](https://github.com/nvm-sh/nvm#bash-completion).

```bash
# Export nvm completion settings for zsh-nvm plugin
export NVM_COMPLETION=true
```
Will result in:

```bash
# Add provided nvm completion
[[ -r $NVM_DIR/bash_completion ]] && \. $NVM_DIR/bash_completion
```