### PR TITLE
perf: dont duplicate work when loading global binaries

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -25,11 +25,11 @@ _zsh_nvm_install() {
 _zsh_nvm_global_binaries() {
 
   # Look for global binaries
-  local global_binary_paths="$(echo "$NVM_DIR"/v0*/bin/*(N) "$NVM_DIR"/versions/*/*/bin/*(N))"
+  local global_binary_paths=($(echo "$NVM_DIR"/v0*/bin/*(N) "$NVM_DIR"/versions/*/*/bin/*(N)))
 
   # If we have some, format them
   if [[ -n "$global_binary_paths" ]]; then
-    echo "$NVM_DIR"/v0*/bin/*(N) "$NVM_DIR"/versions/*/*/bin/*(N) |
+    echo ${(F)global_binary_paths} |
       xargs -n 1 basename |
       sort |
       uniq


### PR DESCRIPTION
I noticed that the glob is run twice. this basically halves the startup time for lazy load