### PR TITLE
Add support for NVM_SILENT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ export NVM_AUTO_USE=true
 antigen bundle lukechilds/zsh-nvm
 ```
 
+### Silent switching
+
+If you use `Auto use` feature of this plugin with a theme that supports node version printing, you may want to disable some messages that nvm prints when it switches between versions. You can disable it by exporting the `NVM_SILENT` environment variable and setting it to `true`.
+
+For example, if you are using antigen, you would put the following in your `.zshrc`:
+
+```shell
+export NVM_SILENT=true
+antigen bundle lukechilds/zsh-nvm
+```
+
 ## Installation
 
 ### Using [Antigen](https://github.com/zsh-users/antigen)

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -174,11 +174,19 @@ _zsh_nvm_auto_use() {
     if [[ "$nvmrc_node_version" = "N/A" ]]; then
       nvm install && export NVM_AUTO_USE_ACTIVE=true
     elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
-      nvm use && export NVM_AUTO_USE_ACTIVE=true
+      if [[ "$NVM_SILENT" = true ]]; then
+        nvm use --silent && export NVM_AUTO_USE_ACTIVE=true
+      else
+        nvm use && export NVM_AUTO_USE_ACTIVE=true
+      fi
     fi
   elif [[ "$node_version" != "$(nvm version default)" ]] && [[ "$NVM_AUTO_USE_ACTIVE" = true ]]; then
-    echo "Reverting to nvm default version"
-    nvm use default
+    if [[ "$NVM_SILENT" = true ]]; then
+      nvm use default --silent
+    else
+      echo "Reverting to nvm default version"
+      nvm use default
+    fi
   fi
 }
 
@@ -216,7 +224,7 @@ if [[ "$ZSH_NVM_NO_LOAD" != true ]]; then
 
     # Enable completion
     [[ "$NVM_COMPLETION" == true ]] && _zsh_nvm_completion
-    
+
     # Auto use nvm on chpwd
     [[ "$NVM_AUTO_USE" == true ]] && add-zsh-hook chpwd _zsh_nvm_auto_use && _zsh_nvm_auto_use
   fi


### PR DESCRIPTION
I'd like to add a feature that disables some messages while switching between multiple versions of node. I use powerlevel10k theme that already prints versions of node so I find it useful to make it possible to disable some verbose messages.