### PR TITLE
Add support for xdg base directory

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -1,6 +1,10 @@
 ZSH_NVM_DIR=${0:a:h}
 
-[[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
+_zsh_nvm_default_install_dir() {
+  [[ -z "${XDG_CONFIG_HOME-}" ]] && echo "$HOME/.nvm" || echo "$XDG_CONFIG_HOME/nvm"
+}
+
+[[ -z "$NVM_DIR" ]] && export NVM_DIR="$(_zsh_nvm_default_install_dir)"
 
 _zsh_nvm_rename_function() {
   test -n "$(declare -f $1)" || return


### PR DESCRIPTION
nvm support XDG Base directory guidelines:

> - If the environment variable $XDG_CONFIG_HOME is present, it will place the nvm files there.

zsh-nvm will now follow these guidelines if configured correctly