### PR TITLE
Add support for NVM_SILENT environment variable #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ export NVM_AUTO_USE=true
 antigen bundle lukechilds/zsh-nvm
 ```
 
+### Silent switching
+
+If you use `Auto use` feature of this plugin with a theme that supports node version printing, you may want to disable some messages that nvm prints when it switches between versions. You can disable it by exporting the `NVM_SILENT` environment variable and setting it to `true`.
+
+For example, if you are using antigen, you would put the following in your `.zshrc`:
+
+```shell
+export NVM_SILENT=true
+antigen bundle lukechilds/zsh-nvm
+```
+
 ## Installation
 
 ### Using [Antigen](https://github.com/zsh-users/antigen)

--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -176,11 +176,19 @@ _zsh_nvm_auto_use() {
     if [[ "$nvmrc_node_version" = "N/A" ]]; then
       nvm install && export NVM_AUTO_USE_ACTIVE=true
     elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
-      nvm use && export NVM_AUTO_USE_ACTIVE=true
+      if [[ "$NVM_SILENT" == true ]]; then
+        nvm use --silent && export NVM_AUTO_USE_ACTIVE=true
+      else
+        nvm use && export NVM_AUTO_USE_ACTIVE=true
+      fi
     fi
   elif [[ "$node_version" != "$(nvm version default)" ]] && [[ "$NVM_AUTO_USE_ACTIVE" = true ]]; then
-    echo "Reverting to nvm default version"
-    nvm use default
+    if [[ "$NVM_SILENT" == true ]]; then
+      nvm use default --silent
+    else
+      echo "Reverting to nvm default version"
+      nvm use default
+    fi
   fi
 }
 


### PR DESCRIPTION
I ran into the same problem discussed in this PR: https://github.com/lukechilds/zsh-nvm/pull/91

Since the PR was nearly complete, I just addressed the comments and submitted it here.

I have tested it and indeed I no longer get the warning (and continue to switch with no output):

**BEFORE**
![Screenshot 2024-03-22 at 4 14 45 PM](https://github.com/lukechilds/zsh-nvm/assets/638937/da096fbc-4090-4597-ba9e-70f6d1f424e3)

**AFTER**
![Screenshot 2024-03-22 at 4 24 06 PM](https://github.com/lukechilds/zsh-nvm/assets/638937/7dcda6b6-3590-4bc4-ade4-44025ff26327)