### PR TITLE
Make NVM_AUTO_USE works even when loaded done

### DIFF
--- a/zsh-nvm.plugin.zsh
+++ b/zsh-nvm.plugin.zsh
@@ -69,6 +69,9 @@ _zsh_nvm_load() {
         ;;
     esac
   }
+
+  [[ "$NVM_AUTO_USE" == true ]] && _zsh_nvm_auto_use
+
 }
 
 _zsh_nvm_completion() {


### PR DESCRIPTION
hello!
My workflow requires me to open and close the terminal a lot, and I hate having to nvm load every time. Thank goodness there is a lazy load option in zsh-nvm.

I'm using it with the following settings (I use oh-my-zsh)
```zsh
export NVM_COMPLETION=true
export NVM_LAZY_LOAD=true
export NVM_LAZY_LOAD_EXTRA_COMMANDS=('nvim', 'git')
export NVM_AUTO_USE=true
```

And I'm using yarn. In zsh-nvm, the lazy load global binaries also includes `yarn`, so when you open a new terminal, it won't be loaded, but when you use yarn commands like `yarn build`, it will be loaded and the node version will automatically be set to the default version (I think because of `nvm use default`!). It's really cool logic.

The only thing is that `NVM_AUTO_USE` only works when the `chpwd` event is called. I'd like it to work when nvm loaded as well.

Syntax like `import packageJson from './package.json' with { type: 'json' }` doesn't work on node v18. In my situation, the nvm default is v18, so the build will fail in the following situation.

```
// .nvmrc
v20
```

```zsh
# First, open a new terminal.
$ # node version is v23.1.0

# Second, run `yarn build`
$ yarn build

# In this case, I want `NVM_AUTO_USE` to work, so that node will be tuned to v20,
# but since the default version is v18, the build fails.
```

So, I tried to modify `NVM_AUTO_USE` so that it works even when nvm load. Actually, I could have just used my fork repository, or simply modified the script in oh-my-zsh locally, but I thought I'd contribute in case there are more cases like mine.

> I've only considered my case, so this might be a pain in the ass in other cases, and I'm still not comfortable with shell scripts, so I'm not sure if this is the right code. (It works well on my local, though, haha)